### PR TITLE
Introduced some formatting changes to adhere to Zend style guidelines…

### DIFF
--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid.php
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/Adminhtml/Block/Catalog/Product/Edit/Tab/Super/Config/Grid.php
@@ -3,12 +3,16 @@
 class OrganicInternet_SimpleConfigurableProducts_Adminhtml_Block_Catalog_Product_Edit_Tab_Super_Config_Grid
     extends Mage_Adminhtml_Block_Catalog_Product_Edit_Tab_Super_Config_Grid
 {
-    #Copied from Magento v1.3.1 code.
-    #Only need to comment out addFilterByRequiredOptions but there's no
-    #nice way of doing that without cutting and pasting the method into my own
-    #derived class. Boo.
-    #This change stops the filtering-out of any configurable product's 'associated products' that have compulsory custom options
-    #Have also replaced parent::_prepareCollection with Mage_Adminhtml_Block_Widget_Grid::_prepareCollection();
+    /**
+     * Copied from Magento v1.3.1 code.
+     * Only need to comment out addFilterByRequiredOptions but there's no
+     * nice way of doing that without cutting and pasting the method into my own
+     * derived class. Boo.
+     * This change stops the filtering-out of any configurable product's 'associated products' that have compulsory custom options
+     * Have also replaced parent::_prepareCollection with Mage_Adminhtml_Block_Widget_Grid::_prepareCollection();
+     *
+     * @return self
+     */    
     protected function _prepareCollection()
     {
         $allowProductTypes = array();
@@ -23,7 +27,7 @@ class OrganicInternet_SimpleConfigurableProducts_Adminhtml_Block_Catalog_Product
             ->addAttributeToSelect('attribute_set_id')
             ->addAttributeToSelect('type_id')
             ->addAttributeToSelect('price')
-            ->addFieldToFilter('attribute_set_id',$product->getAttributeSetId())
+            ->addFieldToFilter('attribute_set_id', $product->getAttributeSetId())
             ->addFieldToFilter('type_id', $allowProductTypes);
             //->addFilterByRequiredOptions();
 
@@ -31,7 +35,7 @@ class OrganicInternet_SimpleConfigurableProducts_Adminhtml_Block_Catalog_Product
 
         foreach ($product->getTypeInstance(true)->getUsedProductAttributes($product) as $attribute) {
             $collection->addAttributeToSelect($attribute->getAttributeCode());
-            $collection->addAttributeToFilter($attribute->getAttributeCode(), array('nin'=>array(null)));
+            $collection->addAttributeToFilter($attribute->getAttributeCode(), array('nin' => array(null)));
         }
 
         $this->setCollection($collection);

--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Block/Product/Price.php
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Block/Product/Price.php
@@ -2,28 +2,39 @@
 class OrganicInternet_SimpleConfigurableProducts_Catalog_Block_Product_Price
     extends Mage_Catalog_Block_Product_Price
 {
-    #This is overridden as an admittedly nasty hack to not have to change the contents of catalog/product/price.phtml
-    #This is because there's no nice way to keep price.phtml in sync between this extension and the magento core version
-    #Yes, it's dependent on the value of $htmlToInsertAfter; I'm not aware of a better alternative.
-    public function _toHtml() {
+    /**
+     * This is overridden as an admittedly nasty hack to not have to change the contents of catalog/product/price.phtml
+     * This is because there's no nice way to keep price.phtml in sync between this extension and the Magento core version
+     * Yes, it's dependent on the value of $htmlToInsertAfter; I'm not aware of a better alternative.
+     * @return string
+     */
+    public function _toHtml()
+    {
         $htmlToInsertAfter = '<div class="price-box">';
+
         if ($this->getTemplate() == 'catalog/product/price.phtml') {
             $product = $this->getProduct();
             if (is_object($product) && $product->isConfigurable()) {
                 $extraHtml = '<span class="label" id="configurable-price-from-'
-                . $product->getId()
-                . $this->getIdSuffix()
-                . '"><span class="configurable-price-from-label">';
+                           . $product->getId()
+                           . $this->getIdSuffix()
+                           . '"><span class="configurable-price-from-label">';
 
                 if ($product->getMaxPossibleFinalPrice() != $product->getFinalPrice()) {
                     $extraHtml .= $this->__('Price From:');
                 }
                 $extraHtml .= '</span></span>';
                 $priceHtml = parent::_toHtml();
-                #manually insert extra html needed by the extension into the normal price html
-                return substr_replace($priceHtml, $extraHtml, strpos($priceHtml, $htmlToInsertAfter)+strlen($htmlToInsertAfter),0);
+                // manually insert extra html needed by the extension into the normal price html
+                return substr_replace(
+                    $priceHtml,
+                    $extraHtml,
+                    strpos($priceHtml, $htmlToInsertAfter) + strlen($htmlToInsertAfter),
+                    0
+                );
             }
-	    }
+        }
+
         return parent::_toHtml();
     }
 }

--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Block/Product/View/Attributes.php
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Block/Product/View/Attributes.php
@@ -1,10 +1,15 @@
 <?php
-class OrganicInternet_SimpleConfigurableProducts_Catalog_Block_Product_View_Attributes extends
-    Mage_Catalog_Block_Product_View_Attributes
+class OrganicInternet_SimpleConfigurableProducts_Catalog_Block_Product_View_Attributes
+    extends Mage_Catalog_Block_Product_View_Attributes
 {
-    #Not sure why mage product_view_attributes block extends Mage_Core_Block_Template instead of say
-    #Mage_Catalog_Block_Product_View_Abstract, but it means that setProduct($product) won't work, so
-    #I've had to add it here.
+    /**
+     * Not sure why mage product_view_attributes block extends Mage_Core_Block_Template instead of say
+     * Mage_Catalog_Block_Product_View_Abstract, but it means that setProduct($product) won't work, so
+     * I've had to add it here.
+     *
+     * @param  Mage_Catalog_Model_Product $product
+     * @return self
+     */
     public function setProduct($product) {
         $this->_product = $product;
         return $this;

--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Block/Product/View/Media.php
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Block/Product/View/Media.php
@@ -1,16 +1,22 @@
 <?php
-
-#SCP: Passed parent productid (which is set by the SCP ajax controller) as the SCP ajax controller needs it again
-#to be able to verify that this simple product belongs to a configurable product that's visible
-
-class OrganicInternet_SimpleConfigurableProducts_Catalog_Block_Product_View_Media extends Mage_Catalog_Block_Product_View_Media {
-
-    public function getGalleryUrl($image=null)
+/**
+ * SCP: Passed parent productid (which is set by the SCP ajax controller) as the SCP ajax controller needs it again
+ * to be able to verify that this simple product belongs to a configurable product that's visible
+ */
+class OrganicInternet_SimpleConfigurableProducts_Catalog_Block_Product_View_Media
+    extends Mage_Catalog_Block_Product_View_Media
+{
+    /**
+     * Get the gallery URL including parameters
+     * @param  object $image
+     * @return string
+     */
+    public function getGalleryUrl($image = null)
     {
-        #$params = array('id'=>$this->getProduct()->getId());
+        // $params = array('id'=>$this->getProduct()->getId());
         $params = array(
-            'id'=>$this->getProduct()->getId(),
-            'pid'=>$this->getProduct()->getCpid()
+            'id'  => $this->getProduct()->getId(),
+            'pid' => $this->getProduct()->getCpid()
         );
         if ($image) {
             $params['image'] = $image->getValueId();

--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Block/Product/View/Type/Configurable.php
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Block/Product/View/Type/Configurable.php
@@ -17,9 +17,9 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Block_Product_View_Type
         foreach ($aProducts as $product) {
             $productId  = $product->getId();
             $childProducts[$productId] = array(
-                "price" => $this->_registerJsPrice($this->_convertPrice($product->getPrice())),
-                "finalPrice" => $this->_registerJsPrice($this->_convertPrice($product->getFinalPrice())),
-                "sku" => $product->getSku(),
+                'price' => $this->_registerJsPrice($this->_convertPrice($product->getPrice())),
+                'finalPrice' => $this->_registerJsPrice($this->_convertPrice($product->getFinalPrice())),
+                'sku' => $product->getSku(),
             );
 
             if (Mage::getStoreConfig('SCP_options/product_page/change_name')) {
@@ -58,35 +58,35 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Block_Product_View_Type
                 $childProducts[$productId]["alertHtml"] = $oAlertBlock->toHtml();
             }
 
-            #if image changing is enabled..
+            // if image changing is enabled..
             if (Mage::getStoreConfig('SCP_options/product_page/change_image')) {
-                #but dont bother if fancy image changing is enabled
+                // but dont bother if fancy image changing is enabled
                 if (!Mage::getStoreConfig('SCP_options/product_page/change_image_fancy')) {
-                    #If image is not placeholder...
-                    if($product->getImage()!=='no_selection') {
+                    // If image is not placeholder...
+                    if ($product->getImage()!=='no_selection') {
                         $childProducts[$productId]["imageUrl"] = (string)Mage::helper('catalog/image')->init($product, 'image');
                     }
                 }
             }
         }
 
-        //Remove any existing option prices.
-        //Removing holes out of existing arrays is not nice,
-        //but it keeps the extension's code separate so if Varien's getJsonConfig
-        //is added to, things should still work.
+        // Remove any existing option prices.
+        // Removing holes out of existing arrays is not nice,
+        // but it keeps the extension's code separate so if Varien's getJsonConfig
+        // is added to, things should still work.
         if (is_array($config['attributes'])) {
             foreach ($config['attributes'] as $attributeID => &$info) {
                 if (is_array($info['options'])) {
                     foreach ($info['options'] as &$option) {
                         unset($option['price']);
                     }
-                    unset($option); //clear foreach var ref
+                    unset($option); // clear foreach var ref
 
                     /* Sort the Options */
                     $info['options'] = $this->_sortOptions($info['options']);
                 }
             }
-            unset($info); //clear foreach var ref
+            unset($info); // clear foreach var ref
         }
 
 
@@ -103,11 +103,11 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Block_Product_View_Type
         $config['shortDescription'] = $this->helper('catalog/output')->productAttribute($p, nl2br($p->getShortDescription()), 'short_description');
 
         if (Mage::getStoreConfig('SCP_options/product_page/change_image')) {
-            $config["imageUrl"] = (string)Mage::helper('catalog/image')->init($p, 'image');
+            $config['imageUrl'] = (string)Mage::helper('catalog/image')->init($p, 'image');
         }
 
         $childBlock = $this->getLayout()->createBlock('catalog/product_view_attributes');
-        $config["productAttributes"] = $childBlock->setTemplate('catalog/product/view/attributes.phtml')
+        $config['productAttributes'] = $childBlock->setTemplate('catalog/product/view/attributes.phtml')
             ->setProduct($this->getProduct())
             ->toHtml();
         
@@ -116,13 +116,13 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Block_Product_View_Type
             $oAlertBlock = $this->getLayout()->createBlock('productalert/product_view')
                     ->setTemplate('productalert/product/view.phtml')
                     ->setSignupUrl(Mage::helper('productalert')->setProduct(Mage::registry('child_product'))->getSaveUrl('stock'));;
-            $config["alertHtml"] = $oAlertBlock->toHtml();
+            $config['alertHtml'] = $oAlertBlock->toHtml();
         }
 
         if (Mage::getStoreConfig('SCP_options/product_page/change_image')) {
             if (Mage::getStoreConfig('SCP_options/product_page/change_image_fancy')) {
                 $childBlock = $this->getLayout()->createBlock('catalog/product_view_media');
-                $config["imageZoomer"] = $childBlock->setTemplate('catalog/product/view/media.phtml')
+                $config['imageZoomer'] = $childBlock->setTemplate('catalog/product/view/media.phtml')
                     ->setProduct($this->getProduct())
                     ->toHtml();
             }
@@ -142,7 +142,11 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Block_Product_View_Type
         //return Mage::helper('core')->jsonEncode($config);
     }
 
-    // preserves the order of attribute options from the position field in the admin attribute option settings
+    /**
+     * Preserves the order of attribute options from the position field in the admin attribute option settings
+     * @param  array $options
+     * @return array
+     */
     protected function _sortOptions($options)
     {
         if (count($options)) {
@@ -154,21 +158,21 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Block_Product_View_Type
             }
 
             // Gather the option_id for all our current options
-            $option_ids = array();
+            $optionIds = array();
             foreach ($options as $option) {
-                $option_ids[] = $option['id'];
+                $optionIds[] = $option['id'];
 
-                $var_name  = 'option_id_'.$option['id'];
-                $$var_name = $option;
+                $varName  = 'option_id_' . $option['id'];
+                $$varName = $option;
             }
 
-            $sql    = "SELECT `option_id` FROM `{$this->_tbl_eav_attribute_option}` WHERE `option_id` IN('".implode('\',\'', $option_ids)."') ORDER BY `sort_order`";
+            $sql    = "SELECT `option_id` FROM `{$this->_tbl_eav_attribute_option}` WHERE `option_id` IN('" . implode('\',\'', $optionIds) . "') ORDER BY `sort_order`";
             $result = $this->_read->fetchCol($sql);
 
             $options = array();
-            foreach ($result as $option_id) {
-                $var_name  = 'option_id_'.$option_id;
-                $options[] = $$var_name;
+            foreach ($result as $optionId) {
+                $varName  = 'option_id_' . $optionId;
+                $options[] = $$varName;
             }
         }
 

--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Product.php
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Product.php
@@ -2,39 +2,51 @@
 class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product
     extends Mage_Catalog_Model_Product
 {
+    /**
+     * Get the maximum possible final price
+     * @return mixed
+     */
     public function getMaxPossibleFinalPrice()
     {
-        if(is_callable(array($this->getPriceModel(), 'getMaxPossibleFinalPrice'))) {
+        if (is_callable(array($this->getPriceModel(), 'getMaxPossibleFinalPrice'))) {
             return $this->getPriceModel()->getMaxPossibleFinalPrice($this);
         } else {
-            #return $this->_getData('minimal_price');
+            // return $this->_getData('minimal_price');
             return parent::getMaxPrice();
         }
     }
 
+    /**
+     * Return whether the product is visible in the site, factoring in its configurable parent
+     * @return boolean
+     */
     public function isVisibleInSiteVisibility()
     {
-        #Force visible any simple products which have a parent conf product.
-        #this will only apply to products which have been added to the cart
-        if(is_callable(array($this->getTypeInstance(), 'hasConfigurableProductParentId'))
-            && $this->getTypeInstance()->hasConfigurableProductParentId()) {
-           return true;
-        } else {
-            return parent::isVisibleInSiteVisibility();
+        // Force visible any simple products which have a parent conf product.
+        // this will only apply to products which have been added to the cart
+        if ((is_callable(array($this->getTypeInstance(), 'hasConfigurableProductParentId')))
+            && ($this->getTypeInstance()->hasConfigurableProductParentId())
+        ) {
+            return true;
         }
+        
+        return parent::isVisibleInSiteVisibility();
     }
 
-
+    /**
+     * Get the product's URL, factoring in its configurable parent
+     * @param  bool $useSid
+     * @return string
+     */
     public function getProductUrl($useSid = null)
     {
-        if(is_callable(array($this->getTypeInstance(), 'hasConfigurableProductParentId'))
-            && $this->getTypeInstance()->hasConfigurableProductParentId()) {
-
+        if ((is_callable(array($this->getTypeInstance(), 'hasConfigurableProductParentId')))
+            && ($this->getTypeInstance()->hasConfigurableProductParentId())
+        ) {
             $confProdId = $this->getTypeInstance()->getConfigurableProductParentId();
             return Mage::getModel('catalog/product')->load($confProdId)->getProductUrl();
-
-        } else {
-            return parent::getProductUrl($useSid);
         }
+        
+        return parent::getProductUrl($useSid);
     }
 }

--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Product/Type/Configurable/Price.php
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Product/Type/Configurable/Price.php
@@ -1,27 +1,37 @@
 <?php
-
-#The methods in there have become a bit convoluted, so it could benefit from a tidy,
-#...though the logic is not that simple any more.
-
+/**
+ * The methods in there have become a bit convoluted, so it could benefit from a tidy,
+ * ...though the logic is not that simple any more.
+ */
 class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product_Type_Configurable_Price
     extends Mage_Catalog_Model_Product_Type_Configurable_Price
 {
-    #We don't want to show a separate 'minimal' price for configurable products.
+    /**
+     * We don't want to show a separate 'minimal' price for configurable products.
+     * @param  Mage_Catalog_Model_Product $product
+     * @return mixed
+     */
     public function getMinimalPrice($product)
     {
         return $this->getPrice($product);
     }
 
-    public function getMaxPossibleFinalPrice($product) {
-        #Indexer calculates max_price, so if this value's been loaded, use it
+    /**
+     * Get maximum possible final price
+     * @param  Mage_Catalog_Model_Product $product
+     * @return mixed
+     */
+    public function getMaxPossibleFinalPrice($product)
+    {
+        // Indexer calculates max_price, so if this value's been loaded, use it
         $price = $product->getMaxPrice();
         if ($price !== null) {
             return $price;
         }
 
         $childProduct = $this->getChildProductWithHighestPrice($product, "finalPrice");
-        #If there aren't any salable child products we return the highest price
-        #of all child products, including any ones not currently salable.
+        // If there aren't any salable child products we return the highest price
+        // of all child products, including any ones not currently salable.
 
         if (!$childProduct) {
             $childProduct = $this->getChildProductWithHighestPrice($product, "finalPrice", false);
@@ -33,21 +43,26 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product_Type_Conf
         return false;
     }
 
-    #If there aren't any salable child products we return the lowest price
-    #of all child products, including any ones not currently salable.
-    public function getFinalPrice($qty=null, $product)
+    /**
+     * If there aren't any salable child products we return the lowest price
+     * of all child products, including any ones not currently salable.
+     * @param  int                        $qty
+     * @param  Mage_Catalog_Model_Product $product
+     * @return mixed
+     */
+    public function getFinalPrice($qty = null, $product)
     {
-/*
-        #calculatedFinalPrice seems not to be set in this version (1.4.0.1)
+        /*
+        // calculatedFinalPrice seems not to be set in this version (1.4.0.1)
         if (is_null($qty) && !is_null($product->getCalculatedFinalPrice())) {
-            #Doesn't usually get this far as Product.php checks first.
-            #Mage::log("returning calculatedFinalPrice for product: " . $product->getId());
+            // Doesn't usually get this far as Product.php checks first.
+            // Mage::log("returning calculatedFinalPrice for product: " . $product->getId());
             return $product->getCalculatedFinalPrice();
         }
-*/
-        $childProduct = $this->getChildProductWithLowestPrice($product, "finalPrice");
+        */
+        $childProduct = $this->getChildProductWithLowestPrice($product, 'finalPrice');
         if (!$childProduct) {
-            $childProduct = $this->getChildProductWithLowestPrice($product, "finalPrice", false);
+            $childProduct = $this->getChildProductWithLowestPrice($product, 'finalPrice', false);
         }
 
         if ($childProduct) {
@@ -60,20 +75,25 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product_Type_Conf
         return $fp;
     }
 
+    /**
+     * Gets the price from a product
+     * @param  Mage_Catalog_Model_Product $product
+     * @return mixed
+     */
     public function getPrice($product)
     {
-        #Just return indexed_price, if it's been fetched already
-        #(which it will have been for collections, but not on product page)
+        // Just return indexed_price, if it's been fetched already
+        // (which it will have been for collections, but not on product page)
         $price = $product->getIndexedPrice();
         if ($price !== null) {
             return $price;
         }
 
-        $childProduct = $this->getChildProductWithLowestPrice($product, "finalPrice");
-        #If there aren't any salable child products we return the lowest price
-        #of all child products, including any ones not currently salable.
+        $childProduct = $this->getChildProductWithLowestPrice($product, 'finalPrice');
+        // If there aren't any salable child products we return the lowest price
+        // of all child products, including any ones not currently salable.
         if (!$childProduct) {
-            $childProduct = $this->getChildProductWithLowestPrice($product, "finalPrice", false);
+            $childProduct = $this->getChildProductWithLowestPrice($product, 'finalPrice', false);
         }
 
         if ($childProduct) {
@@ -83,7 +103,13 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product_Type_Conf
         return false;
     }
 
-    public function getChildProducts($product, $checkSalable=true)
+    /**
+     * Gets the child products from the provided product
+     * @param  Mage_Catalog_Model_Product $product
+     * @param  boolean                    $checkSalable
+     * @return array
+     */
+    public function getChildProducts($product, $checkSalable = true)
     {
         static $childrenCache = array();
         $cacheKey = $product->getId() . ':' . $checkSalable;
@@ -97,8 +123,8 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product_Type_Conf
 
         if ($checkSalable) {
             $salableChildProducts = array();
-            foreach($childProducts as $childProduct) {
-                if($childProduct->isSalable()) {
+            foreach ($childProducts as $childProduct) {
+                if ($childProduct->isSalable()) {
                     $salableChildProducts[] = $childProduct;
                 }
             }
@@ -109,7 +135,7 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product_Type_Conf
         return $childProducts;
     }
 
-/*
+    /*
     public function getLowestChildPrice($product, $priceType, $checkSalable=true)
     {
         $childProduct = $this->getChildProductWithLowestPrice($product, $priceType, $checkSalable);
@@ -124,23 +150,31 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product_Type_Conf
         }
         return $childPrice;
     }
-*/
-    #Could no doubt add highest/lowest as param to save 2 near-identical functions
-    public function getChildProductWithHighestPrice($product, $priceType, $checkSalable=true)
+    */
+   
+    /**
+     * Return the child product with the highest price, specified by $priceType
+     * Could no doubt add highest/lowest as param to save 2 near-identical functions
+     * @param  Mage_Catalog_Model_Product $product
+     * @param  string                     $priceType
+     * @param  boolean                    $checkSalable
+     * @return Mage_Catalog_Model_Product|false
+     */
+    public function getChildProductWithHighestPrice($product, $priceType, $checkSalable = true)
     {
         $childProducts = $this->getChildProducts($product, $checkSalable);
-        if (count($childProducts) == 0) { #If config product has no children
+        if (count($childProducts) == 0) { // If config product has no children
             return false;
         }
         $maxPrice = 0;
         $maxProd = false;
-        foreach($childProducts as $childProduct) {
+        foreach ($childProducts as $childProduct) {
             if ($priceType == "finalPrice") {
                 $thisPrice = $childProduct->getFinalPrice();
             } else {
                 $thisPrice = $childProduct->getPrice();
             }
-            if($thisPrice > $maxPrice) {
+            if ($thisPrice > $maxPrice) {
                 $maxPrice = $thisPrice;
                 $maxProd = $childProduct;
             }
@@ -148,21 +182,28 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product_Type_Conf
         return $maxProd;
     }
 
-    public function getChildProductWithLowestPrice($product, $priceType, $checkSalable=true)
+    /**
+     * Return the child product with the lowest price, specified by $priceType
+     * @param  Mage_Catalog_Model_Product $product
+     * @param  string                     $priceType
+     * @param  boolean                    $checkSalable
+     * @return Mage_Catalog_Model_Product|false
+     */
+    public function getChildProductWithLowestPrice($product, $priceType, $checkSalable = true)
     {
         $childProducts = $this->getChildProducts($product, $checkSalable);
-        if (count($childProducts) == 0) { #If config product has no children
+        if (count($childProducts) == 0) { // If config product has no children
             return false;
         }
         $minPrice = PHP_INT_MAX;
         $minProd = false;
-        foreach($childProducts as $childProduct) {
+        foreach ($childProducts as $childProduct) {
             if ($priceType == "finalPrice") {
                 $thisPrice = $childProduct->getFinalPrice();
             } else {
                 $thisPrice = $childProduct->getPrice();
             }
-            if($thisPrice < $minPrice) {
+            if ($thisPrice < $minPrice) {
                 $minPrice = $thisPrice;
                 $minProd = $childProduct;
             }
@@ -170,8 +211,13 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product_Type_Conf
         return $minProd;
     }
 
-    //Force tier pricing to be empty for configurable products:
-    public function getTierPrice($qty=null, $product)
+    /**
+     * Force tier pricing to be empty for configurable products:
+     * @param  int                        $qty
+     * @param  Mage_Catalog_Model_Product $product
+     * @return array
+     */
+    public function getTierPrice($qty = null, $product)
     {
         return array();
     }

--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Product/Type/Simple.php
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Product/Type/Simple.php
@@ -5,6 +5,7 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product_Type_Simp
     /**
      * Later this should be refactored to live elsewhere probably,
      * but it's ok here for the time being
+     * @return int|false
      */
     private function _getCpid()
     {
@@ -24,6 +25,12 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product_Type_Simp
         return false;
     }
 
+    /**
+     * Add the CPID to the product when preparing for cart
+     * @param  Varien_Object              $buyRequest
+     * @param  Mage_Catalog_Model_Product $product
+     * @return array
+     */
     public function prepareForCart(Varien_Object $buyRequest, $product = null)
     {
         $product = $this->getProduct($product);
@@ -34,6 +41,10 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product_Type_Simp
         return array($product);
     }
 
+    /**
+     * Return whether or not the product has a CPID set
+     * @return boolean
+     */
     public function hasConfigurableProductParentId()
     {
         $cpid = $this->_getCpid();
@@ -41,6 +52,10 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product_Type_Simp
         return !empty($cpid);
     }
 
+    /**
+     * Return the CPID
+     * @return int|false
+     */
     public function getConfigurableProductParentId()
     {
         return $this->_getCpid();

--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Product/Type/Simple.php
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Product/Type/Simple.php
@@ -2,9 +2,11 @@
 class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product_Type_Simple
     extends Mage_Catalog_Model_Product_Type_Simple
 {
-    #Later this should be refactored to live elsewhere probably,
-    #but it's ok here for the time being
-    private function getCpid()
+    /**
+     * Later this should be refactored to live elsewhere probably,
+     * but it's ok here for the time being
+     */
+    private function _getCpid()
     {
         $cpid = $this->getProduct()->getCustomOption('cpid');
         if ($cpid) {
@@ -14,7 +16,7 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product_Type_Simp
         $br = $this->getProduct()->getCustomOption('info_buyRequest');
         if ($br) {
             $brData = unserialize($br->getValue());
-            if(!empty($brData['cpid'])) {
+            if (!empty($brData['cpid'])) {
                 return $brData['cpid'];
             }
         }
@@ -26,21 +28,21 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product_Type_Simp
     {
         $product = $this->getProduct($product);
         parent::prepareForCart($buyRequest, $product);
-        if ($buyRequest->getcpid()) {
-            $product->addCustomOption('cpid', $buyRequest->getcpid());
+        if ($buyRequest->_getcpid()) {
+            $product->addCustomOption('cpid', $buyRequest->_getcpid());
         }
         return array($product);
     }
 
     public function hasConfigurableProductParentId()
     {
-        $cpid = $this->getCpid();
+        $cpid = $this->_getCpid();
         //Mage::log("cpid: ". $cpid);
         return !empty($cpid);
     }
 
     public function getConfigurableProductParentId()
     {
-        return $this->getCpid();
+        return $this->_getCpid();
     }
 }

--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Product/Type/Virtual.php
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Product/Type/Virtual.php
@@ -2,6 +2,12 @@
 class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Product_Type_Virtual
     extends Mage_Catalog_Model_Product_Type_Virtual
 {
+    /**
+     * Add the CPID to virtual products when preparing the cart request
+     * @param  Varien_Object              $buyRequest
+     * @param  Mage_Catalog_Model_Product $product
+     * @return array
+     */
     public function prepareForCart(Varien_Object $buyRequest, $product = null)
     {
         $product = $this->getProduct($product);

--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Configurable.php
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Configurable.php
@@ -2,22 +2,34 @@
 class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Eav_Mysql4_Product_Indexer_Price_Configurable
     extends OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Eav_Mysql4_Product_Indexer_Price_Configurable_Abstract
 {
+    /**
+     * Determine whether stock is managed
+     * @return boolean
+     */
     protected function _isManageStock()
     {
         return Mage::getStoreConfigFlag(Mage_CatalogInventory_Model_Stock_Item::XML_PATH_MANAGE_STOCK);
     }
 
-    #Don't pay any attention to cost of specific conf product options, as SCP doesn't use them
+    /**
+     * Don't pay any attention to cost of specific conf product options, as SCP doesn't use them
+     * @return self
+     */
     protected function _applyConfigurableOption()
     {
         return $this;
     }
 
-    #This calculates final price using SCP logic: minimal child product finalprice
-    #instead of the just the entered configurable price
-    #It uses a subquery/group-by hack to ensure that the various column values are all from the row with the lowest final price.
-    #See Kasey Speakman comment here: http://dev.mysql.com/doc/refman/5.1/en/example-maximum-column-group-row.html
-    #It's all quite complicated. :/
+    /**
+     * This calculates final price using SCP logic: minimal child product finalprice
+     * instead of the just the entered configurable price
+     * It uses a subquery/group-by hack to ensure that the various column values are all from the row with the lowest
+     * final price. It's all quite complicated. See Kasey Speakman comment here:
+     * @link http://dev.mysql.com/doc/refman/5.1/en/example-maximum-column-group-row.html
+     * 
+     * @param  string $entityIds Comma delimited list of IDs
+     * @return self
+     */
     protected function _prepareFinalPriceData($entityIds = null)
     {
 
@@ -27,43 +39,52 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Eav_Mysq
         $select = $write->select()
             ->from(
                 array('e' => $this->getTable('catalog/product')),
-                array())
+                array()
+            )
             ->joinLeft(
                 array('l' => $this->getTable('catalog/product_super_link')),
                 'l.parent_id = e.entity_id',
-                array())
+                array()
+            )
             ->join(
                 array('ce' => $this->getTable('catalog/product')),
                 'ce.entity_id = l.product_id',
-                array())
+                array()
+            )
             ->join(
                 array('pi' => $this->getIdxTable()),
                 'ce.entity_id = pi.entity_id',
-                array())
+                array()
+            )
             ->join(
                 array('cw' => $this->getTable('core/website')),
                 'pi.website_id = cw.website_id',
-                array())
+                array()
+            )
             ->join(
                 array('csg' => $this->getTable('core/store_group')),
                 'csg.website_id = cw.website_id AND cw.default_group_id = csg.group_id',
-                array())
+                array()
+            )
             ->join(
                 array('cs' => $this->getTable('core/store')),
                 'csg.default_store_id = cs.store_id AND cs.store_id != 0',
-                array())
+                array()
+            )
             ->join(
                 array('cis' => $this->getTable('cataloginventory/stock')),
                 '',
-                array())
+                array()
+            )
             ->joinLeft(
                 array('cisi' => $this->getTable('cataloginventory/stock_item')),
                 'cisi.stock_id = cis.stock_id AND cisi.product_id = ce.entity_id',
-                array())
-            ->where('e.type_id=?', $this->getTypeId()); ## is this one needed?
+                array()
+            )
+            ->where('e.type_id=?', $this->getTypeId()); // is this one needed?
 
 
-        $productStatusExpr  = $this->_addAttributeToSelect($select, 'status', 'ce.entity_id', 'cs.store_id');
+        $productStatusExpr = $this->_addAttributeToSelect($select, 'status', 'ce.entity_id', 'cs.store_id');
 
         if ($this->_isManageStock()) {
             $stockStatusExpr = new Zend_Db_Expr('IF(cisi.use_config_manage_stock = 0 AND cisi.manage_stock = 0,' . ' 1, cisi.is_in_stock)');
@@ -72,7 +93,7 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Eav_Mysq
         }
         $isInStockExpr = new Zend_Db_Expr("IF({$stockStatusExpr}, 1, 0)");
 
-        $isValidChildProductExpr = new Zend_Db_Expr("{$productStatusExpr}");
+        $isValidChildProductExpr = new Zend_Db_Expr($productStatusExpr);
 
         $select->columns($this->getInnerColumns());
 
@@ -81,35 +102,42 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Eav_Mysq
             $select->where('e.entity_id IN(?)', $entityIds);
         }
 
-        #Inner select order needs to be:
-        #1st) If it's in stock come first (out of stock product prices aren't used if not-all products are out of stock)
-        #2nd) Finalprice
-        #3rd) $price, in case all finalPrices are NULL. (this gives the lowest price for all associated products when they're all out of stock)
+        /**
+         * 1st) If it's in stock come first (out of stock product prices aren't used if not-all products are out of stock)
+         * 2nd) Finalprice
+         * 3rd) $price, in case all finalPrices are NULL. (this gives the lowest price for all associated products when they're all out of stock)
+         */
         $sortExpr = new Zend_Db_Expr("${isInStockExpr} DESC, pi.final_price ASC, pi.price ASC");
         $select->order($sortExpr);
 
         /**
          * Add additional external limitation
          */
-        Mage::dispatchEvent('prepare_catalog_product_index_select', array(
-            'select'        => $select,
-            'entity_field'  => new Zend_Db_Expr('e.entity_id'),
-            'website_field' => new Zend_Db_Expr('cw.website_id'),
-            'store_field'   => new Zend_Db_Expr('cs.store_id')
-        ));
+        Mage::dispatchEvent(
+            'prepare_catalog_product_index_select',
+            array(
+                'select'        => $select,
+                'entity_field'  => new Zend_Db_Expr('e.entity_id'),
+                'website_field' => new Zend_Db_Expr('cw.website_id'),
+                'store_field'   => new Zend_Db_Expr('cs.store_id')
+            )
+        );
 
-        #This uses the fact that mysql's 'group by' picks the first row, and the subselect is ordered as we want it
-        #Bit hacky, but lots of people do it :)
-        $outerSelect = $write->select()
-            ->from(array("inner" => $select), 'entity_id')
+        /**
+         * This uses the fact that mysql's 'group by' picks the first row, and the subselect is ordered as we want it
+         * Bit hacky, but lots of people do it :)
+         */
+        $outerSelect = $write
+            ->select()
+            ->from(array('inner' => $select), 'entity_id')
             ->group($this->getGroupBy());
 
         $outerSelect->columns($this->getOuterColumns());
 
         $query = $outerSelect->insertFromSelect($this->_getDefaultFinalPriceTable());
         $write->query($query);
-        #Mage::log("SCP Price inner query: " . $select->__toString());
-        #Mage::log("SCP Price outer query: " . $outerSelect->__toString());
+        // Mage::log("SCP Price inner query: " . $select->__toString());
+        // Mage::log("SCP Price outer query: " . $outerSelect->__toString());
 
         return $this;
     }

--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Configurable/Abstract.php
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Configurable/Abstract.php
@@ -1,63 +1,21 @@
 <?php
 
 if (Mage::helper('core')->isModuleEnabled('Innoexts_Warehouse')) {
-/**
- * This class extends InnoExts Multiwarehouse if it's being used.  If so, the stock_id column added by the
- * multiwarehouse module is also included in the index.
- *
- * Class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Eav_Mysql4_Product_Indexer_Price_Configurable_Abstract
- */
-class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Eav_Mysql4_Product_Indexer_Price_Configurable_Abstract
-    extends Innoexts_Warehouse_Model_Mysql4_Catalog_Product_Indexer_Price_Configurable
-{
-
-    protected function getOuterColumns() {
-        return array(
-            'customer_group_id',
-            'website_id',
-            'tax_class_id',
-            'orig_price',
-            'price',
-            'min_price',
-            'max_price'     => new Zend_Db_Expr('MAX(inner.max_price)'),
-            'tier_price',
-            'base_tier',
-            'group_price',
-            'base_group_price',
-            'stock_id', // Extra field introduced by InnoExts Multiwarehouse
-            #'child_entity_id'
-        );
-    }
-
-    protected function getInnerColumns() {
-        return array(
-            'entity_id'         => new Zend_Db_Expr('e.entity_id'),
-            'customer_group_id' => new Zend_Db_Expr('pi.customer_group_id'),
-            'website_id'        => new Zend_Db_Expr('cw.website_id'),
-            'tax_class_id'      => new Zend_Db_Expr('pi.tax_class_id'),
-            'orig_price'        => new Zend_Db_Expr('pi.price'),
-            'price'             => new Zend_Db_Expr('pi.final_price'),
-            'min_price'         => new Zend_Db_Expr('pi.final_price'),
-            'max_price'         => new Zend_Db_Expr('pi.final_price'),
-            'tier_price'        => new Zend_Db_Expr('pi.tier_price'),
-            'base_tier'         => new Zend_Db_Expr('pi.tier_price'),
-            'group_price'       => new Zend_Db_Expr('pi.group_price'),
-            'base_group_price'  => new Zend_Db_Expr('pi.group_price'),
-            'stock_id'      => new Zend_Db_Expr('cis.stock_id') // Extra field introduced by InnoExts Multiwarehouse
-        );
-    }
-
-    protected function getGroupBy() {
-        // stock_id column must be included here to so that a record is created for each stock_id
-        return array('inner.entity_id', 'inner.customer_group_id', 'inner.website_id','inner.stock_id');
-    }
-}
-
-} else {
+    /**
+     * This class extends InnoExts Multiwarehouse if it's being used.  If so, the stock_id column added by the
+     * multiwarehouse module is also included in the index.
+     *
+     * Class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Eav_Mysql4_Product_Indexer_Price_Configurable_Abstract
+     */
     class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Eav_Mysql4_Product_Indexer_Price_Configurable_Abstract
-        extends Mage_Catalog_Model_Resource_Eav_Mysql4_Product_Indexer_Price_Configurable
+        extends Innoexts_Warehouse_Model_Mysql4_Catalog_Product_Indexer_Price_Configurable
     {
-        protected function getOuterColumns() {
+        /**
+         * Return outer columns
+         * @return array
+         */
+        protected function getOuterColumns()
+        {
             return array(
                 'customer_group_id',
                 'website_id',
@@ -65,16 +23,81 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Eav_Mysq
                 'orig_price',
                 'price',
                 'min_price',
-                'max_price'     => new Zend_Db_Expr('MAX(inner.max_price)'),
+                'max_price' => new Zend_Db_Expr('MAX(inner.max_price)'),
                 'tier_price',
                 'base_tier',
                 'group_price',
                 'base_group_price',
-                #'child_entity_id'
+                'stock_id', // Extra field introduced by InnoExts Multiwarehouse
+                //'child_entity_id'
             );
         }
 
-        protected function getInnerColumns() {
+        /**
+         * Return inner columns
+         * @return array
+         */
+        protected function getInnerColumns()
+        {
+            return array(
+                'entity_id'         => new Zend_Db_Expr('e.entity_id'),
+                'customer_group_id' => new Zend_Db_Expr('pi.customer_group_id'),
+                'website_id'        => new Zend_Db_Expr('cw.website_id'),
+                'tax_class_id'      => new Zend_Db_Expr('pi.tax_class_id'),
+                'orig_price'        => new Zend_Db_Expr('pi.price'),
+                'price'             => new Zend_Db_Expr('pi.final_price'),
+                'min_price'         => new Zend_Db_Expr('pi.final_price'),
+                'max_price'         => new Zend_Db_Expr('pi.final_price'),
+                'tier_price'        => new Zend_Db_Expr('pi.tier_price'),
+                'base_tier'         => new Zend_Db_Expr('pi.tier_price'),
+                'group_price'       => new Zend_Db_Expr('pi.group_price'),
+                'base_group_price'  => new Zend_Db_Expr('pi.group_price'),
+                'stock_id'          => new Zend_Db_Expr('cis.stock_id') // Extra field introduced by InnoExts Multiwarehouse
+            );
+        }
+
+        /**
+         * Return the column names to group by
+         * @return array
+         */
+        protected function getGroupBy()
+        {
+            // stock_id column must be included here to so that a record is created for each stock_id
+            return array('inner.entity_id', 'inner.customer_group_id', 'inner.website_id', 'inner.stock_id');
+        }
+    }
+} else {
+    class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Eav_Mysql4_Product_Indexer_Price_Configurable_Abstract
+        extends Mage_Catalog_Model_Resource_Eav_Mysql4_Product_Indexer_Price_Configurable
+    {
+        /**
+         * Return the outer columns
+         * @return array
+         */
+        protected function getOuterColumns()
+        {
+            return array(
+                'customer_group_id',
+                'website_id',
+                'tax_class_id',
+                'orig_price',
+                'price',
+                'min_price',
+                'max_price' => new Zend_Db_Expr('MAX(inner.max_price)'),
+                'tier_price',
+                'base_tier',
+                'group_price',
+                'base_group_price',
+                // 'child_entity_id'
+            );
+        }
+
+        /**
+         * Return the inner columns
+         * @return array
+         */
+        protected function getInnerColumns()
+        {
             return array(
                 'entity_id'         => new Zend_Db_Expr('e.entity_id'),
                 'customer_group_id' => new Zend_Db_Expr('pi.customer_group_id'),
@@ -91,7 +114,12 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Eav_Mysq
             );
         }
 
-        protected function getGroupBy() {
+        /**
+         * Return the column names to group by
+         * @return array
+         */
+        protected function getGroupBy()
+        {
             return array('inner.entity_id', 'inner.customer_group_id', 'inner.website_id');
         }
     }

--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Resource/Product/Collection.php
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Resource/Product/Collection.php
@@ -8,6 +8,7 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Product_
      * This field seems to only appear when the collection has ->addPriceData();
      * 
      * @see Mage_Catalog_Model_Resource_Product_Collection::_productLimitationJoinPrice()
+     * @return self
      */
     protected function _productLimitationJoinPrice()
     {
@@ -18,21 +19,27 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Product_
 
         $helper     = Mage::getResourceHelper('core');
         $connection = $this->getConnection();
-		$select     = $this->getSelect();
-        $joinCond = join(' AND ', array(
-            'price_index.entity_id = e.entity_id',
-            $connection->quoteInto('price_index.website_id = ?', $filters['website_id']),
-            $connection->quoteInto('price_index.customer_group_id = ?', $filters['customer_group_id'])
-        ));
+        $select     = $this->getSelect();
+        $joinCond = join(
+            ' AND ',
+            array(
+                'price_index.entity_id = e.entity_id',
+                $connection->quoteInto('price_index.website_id = ?', $filters['website_id']),
+                $connection->quoteInto('price_index.customer_group_id = ?', $filters['customer_group_id'])
+            )
+        );
 
         $fromPart = $select->getPart(Zend_Db_Select::FROM);
         if (!isset($fromPart['price_index'])) {
-        	$least       = $connection->getLeastSql(array('price_index.min_price', 'price_index.tier_price'));
-            $minimalExpr = $connection->getCheckSql('price_index.tier_price IS NOT NULL',
-                $least, 'price_index.min_price');
+            $least       = $connection->getLeastSql(array('price_index.min_price', 'price_index.tier_price'));
+            $minimalExpr = $connection->getCheckSql(
+                'price_index.tier_price IS NOT NULL',
+                $least,
+                'price_index.min_price'
+            );
             $indexedExpr = new Zend_Db_Expr('price_index.price');
-            $colls = array('indexed_price'=>$indexedExpr,'price', 'tax_class_id', 'final_price', 
-            	'minimal_price'=>$minimalExpr , 'min_price', 'max_price', 'tier_price');
+            $colls = array('indexed_price' => $indexedExpr, 'price', 'tax_class_id', 'final_price', 
+                           'minimal_price' => $minimalExpr, 'min_price', 'max_price', 'tier_price');
             $tableName = array('price_index' => $this->getTable('catalog/product_index_price'));
             $select->join($tableName, $joinCond, $colls);
                 
@@ -45,7 +52,7 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Product_
             $fromPart['price_index']['joinCondition'] = $joinCond;
             $select->setPart(Zend_Db_Select::FROM, $fromPart);
         }
-        //Clean duplicated fields
+        // Clean duplicated fields
         $helper->prepareColumnsList($select);
 
         return $this;

--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Resource/Product/Indexer/Price.php
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Resource/Product/Indexer/Price.php
@@ -3,50 +3,6 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Product_
     extends Mage_Catalog_Model_Resource_Product_Indexer_Price
 {
     /**
-     * Get an array of child IDs by parent product ID
-     * 
-     * @param integer $parentId
-     * 
-     * @return array child_id => child_product type_id
-     */
-    private function getChildIdsByParent($parentId)
-    {
-        $read = $this->_getReadAdapter();
-        $select = $read->select()
-            ->from(array('p' => $this->getTable('catalog/product')), array('entity_id'))
-            ->join(
-                array('pr' => $this->getTable('catalog/product_relation')),
-                'pr.child_id=p.entity_id',
-                array('p.type_id'))
-            ->where('pr.parent_id=?', $parentId);
-        return $read->fetchPairs($select);
-    }
-
-    /**
-     * Get product type from product id
-     * 
-     * catalog_product_entity has the product type.  Not exactly sure why
-     * we're using a join here, but it works.
-     * 
-     * @param integer $id
-     * @return string Product type
-     */
-    private function getProductTypeById($id)
-    {
-        $read = $this->_getReadAdapter();
-        $select = $read->select()
-            ->from(array('pr' => $this->getTable('catalog/product_relation')), array('parent_id'))
-            ->join(
-                array('p' => $this->getTable('catalog/product')),
-                'pr.parent_id=p.entity_id',
-                array('p.type_id'))
-            ->where('pr.parent_id=?', $id);
-        $data = $read->fetchRow($select);
-        return $data['type_id'];
-    }
-
-
-    /**
      * Modified to pull in all sibling associated products' tier prices and
      * to reindex child tier prices when a parent is saved.
      * 
@@ -54,8 +10,8 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Product_
      * Method is responsible for index support
      * when product was saved and changed attribute(s) has an effect on price.
      *
-     * @param Mage_Index_Model_Event $event
-     * @return Mage_Catalog_Model_Resource_Product_Indexer_Price
+     * @param  Mage_Index_Model_Event $event
+     * @return self
      */
     public function catalogProductSave(Mage_Index_Model_Event $event)
     {
@@ -75,10 +31,10 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Product_
         $indexer = $this->_getIndexer($data['product_type_id']);
         $processIds = array($productId);
         if ($indexer->getIsComposite()) {
-            if ($this->getProductTypeById($productId) == 'configurable') {
-                $children = $this->getChildIdsByParent($productId);
+            if ($this->_getProductTypeById($productId) == 'configurable') {
+                $children = $this->_getChildIdsByParent($productId);
                 $processIds = array_merge($processIds, array_keys($children));
-                //Ignore tier and group price data for actual configurable product
+                // Ignore tier and group price data for actual configurable product
                 $tierPriceIds = array_keys($children);
             } else {
                 $tierPriceIds = $productId;
@@ -93,15 +49,15 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Product_
                 $processIds = array_merge($processIds, array_keys($parentIds));
                 $siblingIds = array();
                 foreach (array_keys($parentIds) as $parentId) {
-                    $childIds = $this->getChildIdsByParent($parentId);
+                    $childIds = $this->_getChildIdsByParent($parentId);
                     $siblingIds = array_merge($siblingIds, array_keys($childIds));
                 }
-                if(count($siblingIds)>0) {
+                if (count($siblingIds) > 0) {
                     $processIds = array_unique(array_merge($processIds, $siblingIds));
                 }
                 $this->_copyRelationIndexData(array_keys($parentIds), $productId);
                 $this->_prepareTierPriceIndex($processIds);
-               	$this->_prepareGroupPriceIndex($processIds);
+                $this->_prepareGroupPriceIndex($processIds);
                 $indexer->reindexEntity($productId);
 
                 $parentByType = array();
@@ -124,4 +80,49 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Product_
         return $this;
     }
 
+    /**
+     * Get an array of child IDs by parent product ID
+     * 
+     * @param  integer $parentId
+     * 
+     * @return array child_id => child_product type_id
+     */
+    private function _getChildIdsByParent($parentId)
+    {
+        $read = $this->_getReadAdapter();
+        $select = $read
+            ->select()
+            ->from(array('p' => $this->getTable('catalog/product')), array('entity_id'))
+            ->join(
+                array('pr' => $this->getTable('catalog/product_relation')),
+                'pr.child_id=p.entity_id',
+                array('p.type_id')
+            )
+            ->where('pr.parent_id=?', $parentId);
+        return $read->fetchPairs($select);
+    }
+
+    /**
+     * Get product type from product id
+     * 
+     * catalog_product_entity has the product type.  Not exactly sure why
+     * we're using a join here, but it works.
+     * 
+     * @param  integer $id
+     * @return string Product type
+     */
+    private function _getProductTypeById($id)
+    {
+        $read = $this->_getReadAdapter();
+        $select = $read->select()
+            ->from(array('pr' => $this->getTable('catalog/product_relation')), array('parent_id'))
+            ->join(
+                array('p' => $this->getTable('catalog/product')),
+                'pr.parent_id=p.entity_id',
+                array('p.type_id')
+            )
+            ->where('pr.parent_id=?', $id);
+        $data = $read->fetchRow($select);
+        return $data['type_id'];
+    }
 }


### PR DESCRIPTION
### Magento/Zend style guideline formatting changes
- Changed tab indentation to spaces where appropriate
- Use PHPdoc blocks for all methods
- Specify `@return self` instead of the full class name
- Prefix private methods with underscores (protected methods left alone in case of classes extending them)
- Changed inline comments to use `//` comments instead of `#`
- Use single quotes instead of double quotes
- Camel casing for variable names instead of underscored
- Added spaces between control structure segments and array declarations
